### PR TITLE
Fix sendMessage for spectators, remove stale libp2p node

### DIFF
--- a/packages/client/src/app/ui/Chat/Chat.tsx
+++ b/packages/client/src/app/ui/Chat/Chat.tsx
@@ -67,7 +67,6 @@ export function Chat() {
       "/dns4/canvas-chat-discovery-p0.fly.dev/tcp/443/wss/p2p/12D3KooWG1zzEepzv5ib5Rz16Z4PXVfNRffXBGwf7wM8xoNAbJW7",
       "/dns4/canvas-chat-discovery-p1.fly.dev/tcp/443/wss/p2p/12D3KooWNfH4Z4ayppVFyTKv8BBYLLvkR1nfWkjcSTqYdS4gTueq",
       "/dns4/canvas-chat-discovery-p2.fly.dev/tcp/443/wss/p2p/12D3KooWRBdFp5T1fgjWdPSCf9cDqcCASMBgcLqjzzBvptjAfAxN",
-      "/dns4/peer.canvasjs.org/tcp/443/wss/p2p/12D3KooWFYvDDRpXtheKXgQyPf7sfK2DxS1vkripKQUS2aQz5529",
     ],
   });
 
@@ -137,7 +136,7 @@ export function Chat() {
       await app.actions.createMessage({
         content: newMessage,
         name,
-        color: currentPlayer?.playerColor.color.toString(16),
+        color: currentPlayer?.playerColor.color.toString(16) || "",
       });
       sendAnalyticsEvent("sent-message", { matchEntity });
     } catch (err) {


### PR DESCRIPTION
Somehow I didn't notice this until the last day of Season 2 - inside packages/client/src/app/ui/Chat/Chat.tsx, sendMessage may be called with `undefined` since spectators no longer have a color. (I think this was rolled up into all the changes that went into Season 2.) This causes an error for spectators when sending a message since [IPLD](https://github.com/ipld/js-dag-cbor) throws an error when encoding undefined. This may have been a root cause behind why users were running into issues with chat.

I'm adding checks on our side to prevent this from causing problems in the future, but this PR just works around it by sending an empty string, if the player doesn't have a color.

It also removes an extra p2p node that we took down earlier this year that was clogging up the console with connectivity errors.